### PR TITLE
feat: Stringify NaN and infinite values in experiment properties

### DIFF
--- a/python/experiment/service/db.py
+++ b/python/experiment/service/db.py
@@ -4321,6 +4321,7 @@ class ExperimentRestAPI:
             self,
             rest_uid: str,
             include_properties: List[str] | None = None,
+            stringify_nan: bool = False,
             query: Optional[DictMongoQuery] = None,
             _api_verbose:bool = True):
         """Retrieve the `experiment` Document associated with the rest_uid that the ST4SD Runtime Service REST-API
@@ -4338,6 +4339,7 @@ class ExperimentRestAPI:
                 columns in that DataFrame will be those specified in `include_properties`. Column names that do not
                 exist will in the DataFrame will be silently discarded. The column `input-id` will always be fetched
                 even if not specified in `include_properties`.
+            stringify_nan: A boolean flag that allows converting NaN and infinite values to strings
             query: A mongo query to use for further filtering results
             _api_verbose: Set to true to print INFO level messages
 
@@ -4359,6 +4361,7 @@ class ExperimentRestAPI:
         ret = self.cdb_get_document_experiment(
             query=query,
             include_properties=include_properties,
+            stringify_nan=stringify_nan,
             _api_verbose=_api_verbose)
 
         if len(ret) == 0:


### PR DESCRIPTION
## Context

Fixes https://github.com/st4sd/st4sd-runtime-core/issues/6

The "NaN" and "infinite" values are not part of the JSON standard. When we serialize entries with NaN or inf we are actually creating an invalid JSON document that is made possible by Python's default behavior for `json` (which is `allow_nan=True`). If `allow_nan` is set to False, then an exception would be raised.

## Solution
We could add a flag such as `stringify_nan` which defaults to `False` that allows for converting NaN and infinite values to the string NaN/inf. This would allow services such as the Registry Backend to then serve valid JSON.

The issue could be fixed by adding in the line before the Dataframe is converted to dict (here: https://github.ibm.com/st4sd/st4sd-runtime-core/blob/master/python/experiment/service/db.py#L1137) a call to Pandas's `fillna` function, as such: 

```python
df.fillna('NaN', inplace=True)
```

For infinite values, instead, we will have to use the `df.replace` method

## Done when

- [x] We have a flag that allows stringifying NaN values