### PR TITLE
bug: fix print statement when restarting LSF worker (#173)

### DIFF
--- a/python/experiment/runtime/backend_interfaces/lsf.py
+++ b/python/experiment/runtime/backend_interfaces/lsf.py
@@ -1532,8 +1532,9 @@ class LSFRequestArbitrator(object):
         timeout = self.workerNotifyInterval + 60
         for workerId in list(self.workerStatusDict.keys()):
             delta = now - self.workerStatusDict[workerId]
-            if  delta > datetime.timedelta(seconds=timeout):
-                self.log.warning('Worker process %d has not reported in %d seconds - terminating' % (workerId, delta))
+            if delta > datetime.timedelta(seconds=timeout):
+                self.log.warning('Worker process %d has not reported in %f seconds - terminating' % (
+                    workerId, delta.total_seconds()))
                 self.requestHandlers[workerId].terminate()
                 p = multiprocessing.Process(target=RequestHandler,
                                             args=(workerId,


### PR DESCRIPTION
## Context

When a LSF worker loses connection to LSF st4sd attempts to restart the worker so that it reconnects to the LSF daemon. However the code that restarts the worker runs into an exception right before it restarts the worker process

```
INFO      StatusMonitor                  output.statusmonitor          : CheckStatus          2023-02-10 18:22:06,179: Status of stage0: 0.3333 0.3333 running (active-stages: {0:0.33})
Cannot connect to LSF. Please wait ...
Cannot connect to LSF. Please wait ...
Cannot connect to LSF. Please wait ...
Cannot connect to LSF. Please wait ...
INFO      StatusMonitor                  output.statusmonitor          : compute_stage_status 2023-02-10 18:22:36,184: Stage 0 does not define a status script, will take into account component completion
INFO      StatusMonitor                  control.controller            : get_stage_status     2023-02-10 18:22:36,184: Status report for stage0 2/6 = 0.333333
INFO      StatusMonitor                  output.statusmonitor          : CheckStatus          2023-02-10 18:22:36,185: Status of stage0: 0.3333 0.3333 running (active-stages: {0:0.33})
INFO      StatusMonitor                  output.statusmonitor          : compute_stage_status 2023-02-10 18:23:06,190: Stage 0 does not define a status script, will take into account component completion
INFO      StatusMonitor                  control.controller            : get_stage_status     2023-02-10 18:23:06,190: Status report for stage0 2/6 = 0.333333
INFO      StatusMonitor                  output.statusmonitor          : CheckStatus          2023-02-10 18:23:06,191: Status of stage0: 0.3333 0.3333 running (active-stages: {0:0.33})
WARNING   Thread-1                       lsf.task.ProcessWorkkers      : ProcessWorkers       2023-02-10 18:23:32,850: Encountered error processing workers: %d format: a number is required, not datetime.timedelta.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/opt/share/beta/Python-3.7.9/x86_64/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/opt/share/beta/Python-3.7.9/x86_64/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/path/ST4SD/venvs/st4sd/lib/python3.7/site-packages/experiment/runtime/backend_interfaces/lsf.py", line 1373, in ProcessWorkers
    instance.processWorkers()
  File "/path/ST4SD/venvs/st4sd/lib/python3.7/site-packages/experiment/runtime/backend_interfaces/lsf.py", line 1536, in processWorkers
    self.log.warning('Worker process %d has not reported in %d seconds - terminating' % (workerId, delta))
TypeError: %d format: a number is required, not datetime.timedelta
```

## Change list
- [x] The log statement in the `processWorkers()` method above does not raise the above `TypeError` exception