### PR TITLE
feat: Make number of worker threads in rx.SchedulerPools configurable

### DIFF
--- a/python/experiment/runtime/utilities/rx.py
+++ b/python/experiment/runtime/utilities/rx.py
@@ -4,11 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Author(s): Vassilis Vassiliadis
 
-from __future__ import print_function
-
 import logging
+import threading
 import traceback
-from typing import Any, Callable, Optional
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Dict
+import reactivex.scheduler
+
+import enum
+import experiment.settings
 
 logger = logging.getLogger('rx_utils')
 
@@ -36,3 +42,67 @@ def report_exceptions(cb, log=None, label=None):
             raise e
 
     return wrapper
+
+
+class ThreadPoolGenerator:
+    _mtx = threading.Lock()
+    _pools: Dict[str, reactivex.scheduler.ThreadPoolScheduler] = {}
+
+    class Pools(enum.Enum):
+        BackendK8s = "BackendK8s"
+        Controller = "Controller"
+        ComponentState = "ComponentState"
+        Engine = "Engine"
+        EngineTrigger = "EngineTrigger"
+        EngineTask = "EngineTask"
+
+    # VV: this maps the known pool identifiers to their corresponding field names in experiment.settings.Orchestrator
+    # that determine their size in terms of number of worker threads.
+    _poolname_to_workers_options_field = {
+        Pools.BackendK8s.value: "workers_backend_k8s",
+        Pools.Controller.value: "workers_controller",
+        Pools.ComponentState.value: "workers_component_state",
+        Pools.Engine.value: "workers_engine",
+        Pools.EngineTrigger.value: "workers_engine_trigger",
+        Pools.EngineTask.value: "workers_engine_task",
+    }
+
+    @classmethod
+    def get_pool(cls, pool: Pools) -> reactivex.scheduler.ThreadPoolScheduler:
+        """Returns the RX workerpool - if pool doesn't exist it generates first
+
+        The method may cause the orchestrator to parse and validate Environment Variables (to determine size of pools)
+        in the scenario where no method has parsed the environment variables before (not feasible if using elaunch.py
+        or cexecute.py)
+
+        Arguments:
+            pool: The identifier of a pool, see the class ThreadPoolGenerator.Pools for valid identifiers
+
+        Returns: An reactivex.scheduler.ThreadPoolScheduler object
+        Raises:
+            KeyError:
+                If @pool is an unknown Pool identifier
+            experiment.model.errors.EnhancedException:
+                If method is the first caller to experiment.settings.load_settings_orchestrator() and
+                the parsed environment variables are wrong. The exception will explain which environment variables
+                were invalid
+        """
+        if pool.value not in cls._poolname_to_workers_options_field:
+            raise KeyError(f"Unknown pool {pool.value}")
+
+        # VV: After the first few calls to this method all pools will have been generated, so try an erly-exit here
+        if pool.value in cls._pools:
+            return cls._pools[pool.value]
+
+        with cls._mtx:
+            if pool.value not in cls._pools:
+                # VV: The first call to load_settings_orchestrator() will parse and validate environment variables.
+                # Subsequent calls return a reference to the last parsed Settings
+                # (provided that reuse_if_existing is set to True for those calls)
+                orchestrator = experiment.settings.load_settings_orchestrator(reuse_if_existing=True)
+
+                field = cls._poolname_to_workers_options_field[pool.value]
+                workers = getattr(orchestrator, field)
+                cls._pools[pool.value] = reactivex.scheduler.ThreadPoolScheduler(workers)
+
+        return cls._pools[pool.value]

--- a/python/experiment/settings.py
+++ b/python/experiment/settings.py
@@ -1,0 +1,149 @@
+
+# Copyright IBM Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pydantic
+from typing import Optional
+from typing import Dict
+import os
+
+import experiment.model.errors
+
+
+class Orchestrator(pydantic.BaseModel):
+    """
+    Example environment variables: ST4SD_ORCHESTRATOR_WORKERS_DEFAULT_ALL
+    Use the load_settings_orchestrator() method to parse and validate settings (method raises errors that
+    include information about offending environment variables)
+    """
+    class Config:
+        extra = pydantic.Extra.forbid
+
+    workers_default_all: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        None, description="If set, sets the default value to all worker polls. This will override the default of "
+                          "other individual fields. Users can still override those defaults by specifying an explicit "
+                          "value.")
+    workers_controller: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        40, description="Number of workers in the Controller threadPool")
+    workers_component_state: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        50, description="Number of workers in the ComponentState threadPool")
+    workers_engine: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        50, description="Number of workers in the Engine threadPool")
+    workers_engine_trigger: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        20, description="Number of workers in the Engine threadPool that Engines use to trigger immediate emissions")
+    workers_engine_task: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        100, description="Number of workers in the Engine threadPool that Engines use to wait for tasks to complete")
+    workers_backend_k8s: Optional[pydantic.conint(ge=1)] = pydantic.Field(
+        50, description="Number of workers in the Backend.Kubernetes threadPool")
+
+    @pydantic.root_validator(pre=True)
+    def set_defaults(cls, value: Dict[str, str]) -> Dict[str, str]:
+        """If workers_default_all is set (and it's a valid value) then copy it to all fields that are not set
+
+        Argument:
+            value: The dictionary that contains key: value definitions of the BaseModel
+
+        Returns:
+            A post-processed dictionary with key: value definitions of the BaseModel which may have fields replaced
+            to the value of workers_default_all.
+        """
+        label = 'workers_default_all'
+        if isinstance(value, dict) and isinstance(value.get(label), str):
+            try:
+                # VV: we don't care about the value other than it's a positive integer, we'll still need to set
+                # the values of fields to strings. Pydantic runs this method before it parses the values of
+                # the dictionary we return to it.
+                workers_all = int(value[label])
+            except TypeError:
+                return value
+
+            if workers_all < 1:
+                return value
+
+            for k in cls.__fields__:
+                if k == label or k in value:
+                    continue
+                value[k] = value[label]
+
+        return value
+
+
+# VV: use load_settings_orchestrator() to parse environment variables and cache them under _OrchestratorCache
+_OrchestratorCache: Orchestrator | None = None
+_mtx = threading.Lock()
+
+
+def load_settings_orchestrator(
+        environ: Optional[Dict[str, str]] = None,
+        env_prefix: str = "ST4SD_ORCHESTRATOR_",
+        reuse_if_existing: bool = True,
+) -> Orchestrator:
+    """Loads orchestrator settings from Environment Variables and Caches the parsed value
+
+    Note::
+
+        The return value of this method is a reference to the pydantic BaseModel containing the orchestartor
+        Settings
+
+    Arguments:
+        environ: A dictionary containing environment variables and their values. If None defaults to os.environ.
+            If set to the empty dictionary ({}) the method loads the default values of the Orchestrator BaseModel.
+            Read definition of @reuse_if_existing argument.
+        env_prefix: The prefix for the orchestrator environment variable names. The default is ST4SD_ORCHESTRATOR_
+            The names of the variables are ${env_prefix}${Orchestrator.Field.upper()}
+        reuse_if_existing: If True (default) and the settings have already been loaded before, the method will return
+            the existing Settings (i.e. _OrchestratorCache). If True, and settings have been cached, and environ
+            has changed since then, the caller will still receive the old (and potentially stale) Settings
+
+    Returns: An Orchestrator object, it also sets the global _OrchestratorCache variable
+    Raises:
+        experiment.model.errors.EnhancedException:
+            If environment variables are wrong. The underlyingError is a modified pydantic.ValidationError that
+            encapsulates the name and value of the invalid environment variable.
+    """
+    global _OrchestratorCache
+
+    # VV: If caller wishes to reuse cached values try for an early-exit here (i.e. without locking the mutex)
+    # This is the path that most callers will follow during the orchestration of experiment instances
+    if _OrchestratorCache is not None and reuse_if_existing:
+        return _OrchestratorCache
+
+    # VV: past this point we need to parse and validate the environment variables
+    with _mtx:
+        # VV: Do the check one more time so that if multiple threads attempted to load the settings, all but the 1st
+        # get an early exit (provided that they wish to reuse an existing collection of settings)
+        if _OrchestratorCache is not None and reuse_if_existing:
+            return _OrchestratorCache
+
+        _OrchestratorCache = None
+        environ = environ if environ is not None else os.environ
+
+        from_environ = {}
+        env_vars = {}
+        for setting_name in Orchestrator.__fields__:
+            env_var_name = "".join([env_prefix, setting_name.upper()])
+            if env_var_name in environ:
+                env_vars[setting_name] = environ[env_var_name]
+                from_environ[env_var_name] = environ[env_var_name]
+
+        try:
+            _OrchestratorCache = Orchestrator(**env_vars)
+            return _OrchestratorCache
+        except pydantic.ValidationError as e:
+            # VV: Update the Exception in-place to reflect which environment variables were invalid
+            errors = e.errors()
+            for problem in errors:
+                if 'loc' in problem and len(problem['loc']) == 1:
+                    setting_name = problem['loc'][0]
+
+                    if setting_name in env_vars:
+                        env_var_name = "".join([env_prefix, setting_name.upper()])
+                        problem['loc'] = (f'{env_var_name}="{env_vars[setting_name]}"',)
+            raise experiment.model.errors.EnhancedException(
+                f"The environment {from_environ} is invalid. The errors are {json.dumps(errors, indent=2)}",
+                underlyingError=e) from e

--- a/scripts/cexecute.py
+++ b/scripts/cexecute.py
@@ -24,6 +24,7 @@ import os
 import sys
 import threading
 
+import experiment.settings
 import experiment.appenv
 import experiment.runtime.backends
 import experiment.model.conf
@@ -156,6 +157,10 @@ if __name__ == "__main__":
                       action="store_true",
                       metavar="REPAIR_SHADOW_DIR",
                       default=False)
+
+    # VV: Load tne environment variables that define the size of worker pools and other Orchestrator settings
+    # this may raise an exception explaining which environment-variable is invalid
+    experiment.settings.load_settings_orchestrator()
 
     #Set umask to 0002 to allow group write
     os.umask(0o002)

--- a/scripts/elaunch.py
+++ b/scripts/elaunch.py
@@ -37,6 +37,8 @@ import yaml
 from future.utils import raise_with_traceback
 from six import string_types
 
+
+import experiment.settings
 import experiment.appenv
 
 import experiment.test
@@ -1628,6 +1630,14 @@ if __name__ == "__main__":
                     error_description = str(initialization_error)
                 compExperiment.statusFile.setErrorDescription(error_description)
             compExperiment.statusFile.update()
+
+    # VV: Load the environment variables that define the size of worker pools and other Orchestrator settings
+    # do this after creating the instance (to preserve the error) but before initializing the components
+    if initialization_error is None:
+        try:
+            experiment.settings.load_settings_orchestrator()
+        except experiment.model.errors.EnhancedException as e:
+            initialization_error = e
 
     if initialization_error is not None or compExperiment is None:
         rootLogger.warning("Error detected, will now terminate")

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     #   Issue is not resolved -> see https://github.ibm.com/hartreechem/flow/issues/1097 and linked issues
     install_requires=['reactivex>=4.0.0', 'pyyaml', 'pytest', 'pytest-xdist', 'pytest-timeout',
                       'networkx', 'matplotlib<3.4.0', 'requests', 'six', 'kubernetes', 'psutil', 'boto3',
-                      'pyrsistent', 'js2py', 'pymongo>=4.0', 'papermill', 'pandas', 'future'
+                      'pyrsistent', 'js2py', 'pymongo>=4.0', 'papermill', 'pandas', 'future', 'pydantic'
                       ], #, 'pygraphviz'],
 
     # List additional groups of dependencies here (e.g. development

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,51 @@
+import experiment.settings
+
+
+def test_parse_options_from_environment_variables():
+    orig = experiment.settings.load_settings_orchestrator(reuse_if_existing=False)
+
+    try:
+        environ = dict()
+
+        environ['ST4SD_ORCHESTRATOR_WORKERS_CONTROLLER'] = '1'
+        environ['ST4SD_ORCHESTRATOR_WORKERS_COMPONENT_STATE'] = '2'
+        environ['ST4SD_ORCHESTRATOR_WORKERS_ENGINE'] = '3'
+        environ['ST4SD_ORCHESTRATOR_WORKERS_ENGINE_TRIGGER'] = '4'
+        environ['ST4SD_ORCHESTRATOR_WORKERS_ENGINE_TASK'] = '5'
+        environ['ST4SD_ORCHESTRATOR_WORKERS_BACKEND_K8S'] = '6'
+
+        custom = experiment.settings.load_settings_orchestrator(environ=environ, reuse_if_existing=False)
+
+        assert custom.workers_default_all is None
+        assert custom.workers_controller == 1
+        assert custom.workers_component_state == 2
+        assert custom.workers_engine == 3
+        assert custom.workers_engine_trigger == 4
+        assert custom.workers_engine_task == 5
+        assert custom.workers_backend_k8s == 6
+
+        assert orig.dict() != custom.dict()
+    finally:
+        restored = experiment.settings.load_settings_orchestrator(reuse_if_existing=False)
+        assert orig.dict() == restored.dict()
+
+
+def test_override_defaults():
+    orig = experiment.settings.load_settings_orchestrator(reuse_if_existing=False)
+
+    try:
+        environ = {'ST4SD_ORCHESTRATOR_WORKERS_DEFAULT_ALL': '424242'}
+        custom = experiment.settings.load_settings_orchestrator(environ=environ, reuse_if_existing=False)
+
+        assert custom.workers_default_all == 424242
+        assert custom.workers_controller == 424242
+        assert custom.workers_component_state == 424242
+        assert custom.workers_engine == 424242
+        assert custom.workers_engine_trigger == 424242
+        assert custom.workers_engine_task == 424242
+        assert custom.workers_backend_k8s == 424242
+
+        assert orig.dict() != custom.dict()
+    finally:
+        restored = experiment.settings.load_settings_orchestrator(reuse_if_existing=False)
+        assert orig.dict() == restored.dict()


### PR DESCRIPTION
### Context

Elaunch uses a number of ThreadPoolSchedulers and NewThreadSchedulers. However, the sizes of these ThreadPools are not configurable by users. We would like to be able to control the number of threads inside those ThreadPools at the beginning of an experiment so that it's possible to tune them for the hardware that they use to execute elaunch.py on

Environment variables:

- ST4SD_ORCHESTRATOR_WORKERS_DEFAULT_ALL (controls default value of pools, defining any of the other env-vars overrides this setting)
- ST4SD_ORCHESTRATOR_WORKERS_CONTROLLER
- ST4SD_ORCHESTRATOR_WORKERS_COMPONENT_STATE
- ST4SD_ORCHESTRATOR_WORKERS_ENGINE
- ST4SD_ORCHESTRATOR_WORKERS_ENGINE_TRIGGER
- ST4SD_ORCHESTRATOR_WORKERS_ENGINE_TASK
- ST4SD_ORCHESTRATOR_WORKERS_BACKEND_K8S

For example:

```
export ST4SD_ORCHESTRATOR_WORKERS_DEFAULT_ALL=5
```

Configures all pools to 5 worker threads.

```
export ST4SD_ORCHESTRATOR_WORKERS_DEFAULT_ALL=5
export ST4SD_ORCHESTRATOR_WORKERS_CONTROLLER=10
```

Configures the Controller workerPool to 10 workers and all the other ones to 5.
## Change list
- [x] environment variables to control threadpool sizes