### PR TITLE
feat: Support for :link and :copy in --applicationDependencySource

### DIFF
--- a/python/experiment/test.py
+++ b/python/experiment/test.py
@@ -54,7 +54,10 @@ def ValidatePackage(
         instance_name: if not none instead of using Path(packagePath).with_suffix('.instance') name will be used
            can be combined with stamp
         custom_application_sources(Dict[str, str]): Overrides source of application dependencies, format is
-               {"<application_dependency_entry_name>": "/absolute/path"}
+               {"<application_dependency_entry_name>": "/absolute/path[:link/copy]"}
+               The :link and :copy suffixes determine whether to link or copy the path under the instance directory.
+               The suffix is optional and defaults to :link. If the path contains a ':' character,
+               use '%3A' instead (i.e. url-encode the : character)"
 
     Returns:
          a tuple with three elements (isValid, error, Experiment)

--- a/scripts/elaunch.py
+++ b/scripts/elaunch.py
@@ -803,7 +803,7 @@ class LivePatcher:
             # VV: Ensure that all application_dependencies and virtual_environments are linked
 
             application_dependencies = new_concrete.get_application_dependencies()
-            experiment.model.data.Experiment._createApplicationLinks(
+            experiment.model.data.Experiment._populateApplicationSources(
                 application_dependencies, cls.comp_experiment.instanceDirectory.packagePath,
                 cls.comp_experiment.instanceDirectory, ignore_existing=True,
                 custom_application_sources=cls.custom_application_sources
@@ -1239,7 +1239,10 @@ def build_parser() -> NoSystemExitOptparseOptionParser:
                                   "considered a security risk and should be avoided. Default is No.")
     launchOptions.add_option("-s", "--applicationDependencySource", dest="application_dependency_source",
                              help="Point an application dependency to a specific "
-                                  "path on the filesystem `applicationDependencyEntry:/path/to/new/source`",
+                                  "path on the filesystem `applicationDependencyEntry:/path/to/new/source[:link/:copy]`"
+                                  "The :link and :copy suffixes determine whether to link or copy the path under the "
+                                  "instance directory. They suffix is optional and defaults to :link. If the path "
+                                  "contains a ':' character, use '%3A' instead (i.e. url-encode the : character)",
                              default=[], metavar="APPLICATION_DEPENDENCY_SOURCE", action="append")
     launchOptions.add_option('', '--manifest', dest="manifest", metavar="PATH_TO_MANIFEST_FILE", default=None,
                              help="Optional path to manifest YAML file to use when setting up package directory from a "


### PR DESCRIPTION
### Context
Closes #10 

For example,

--applicationDependencySource=appDep:path/hello[:copy/:link]

The :copy and :link suffix is optional and defaults to :link.

If the path contains the `:` character, replace it with `%3A`.

Complete example:

--applicationDependencySource=appDep:/tmp/hello%3Ahi:copy

Copies the directory `/tmp/hello:hi` as `$INSTANCE_DIR_NAME/appDep`

Refs https://github.ibm.com/st4sd/st4sd-runtime-core/issues/163
Signed-off-by: Vassilis Vassiladis <vassilis.vassiliadis@ibm.com>

## Change list

- Updates elaunch.py argument to `--applicationDependencySource=appDep:some/path[:copy/:link]`
- The `:copy` and `:link` suffix is new and optional (defaults to `:link` for backwards compatibility) 
- If path contains the `:` character, the user is expected to replace it with `%3A`

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
