### PR TITLE
build: support building python 3.10 image and pip wheel

### DIFF
--- a/py310.Dockerfile
+++ b/py310.Dockerfile
@@ -1,0 +1,83 @@
+# Copyright IBM Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG base_image=ubuntu:22.04
+
+FROM $base_image
+# VV: Builder image
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y \
+       python3.10 python3-pip python3-tk git python3-rdkit locales curl libffi-dev libssl-dev \
+       libpng-dev libjpeg-dev libfreetype6-dev pkg-config libxml2-dev libxslt-dev libpython3.10-dev \
+       libzmq3-dev
+ENV LANGUAGE=en
+ENV LC_ALL en_GB.UTF-8
+ENV LANG en_GB.UTF-8
+
+RUN locale-gen ${LC_ALL}
+
+RUN python3 -m pip install --upgrade pip virtualenv setuptools six tox && \
+    python3 -m pip install papermill 
+RUN mkdir /venvs
+
+ENV PIP_DEFAULT_TIMEOUT=120
+
+COPY ./ st4sd-runtime-core
+
+ENV VIRTUAL_ENV=/venvs/st4sd-runtime-core
+
+RUN cd /st4sd-runtime-core && \
+    export DEPLOY_VENV=${VIRTUAL_ENV} && \
+    export TOX_ENV=py310-deploy && \
+    tox -e $TOX_ENV -vv && \
+    chmod a+rwx ${VIRTUAL_ENV}/* && \
+    chmod a+rwx ${VIRTUAL_ENV}/*/*/*
+
+RUN PATH=${VIRTUAL_ENV}/bin:${PATH} pip3 install twine
+RUN cd /st4sd-runtime-core && \
+    export PATH=${VIRTUAL_ENV}/bin:${PATH} && \
+    python3 setup.py sdist bdist_wheel
+
+# VV: Runtime image
+FROM $base_image
+
+ENV LANGUAGE=en
+ENV LC_ALL en_GB.UTF-8
+ENV LANG en_GB.UTF-8
+
+# VV: Install system-wide pip and python-tk for matplotlib for consistency with moved virtual-env
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y --no-install-recommends python3.10 python3-pip python3-tk libffi-dev python3-rdkit vim-tiny \
+       locales libzmq3-dev && \
+    locale-gen ${LC_ALL} && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo 'You can find the licenses of GPL packages in this container under \n\
+/usr/share/doc/${PACKAGE_NAME}/copyright \n\
+\n\
+If you would like the source to the GPL packages in this image then \n\
+send a request to this address, specifying the package you want and \n\
+the name and hash of this image: \n\
+\n\
+IBM Research Ireland,\n\
+IBM Technology Campus\n\
+Damastown Industrial Park\n\
+Mulhuddart Co. Dublin D15 HN66\n\
+Ireland\n' >/gpl-licenses
+
+ENV VIRTUAL_ENV=/venvs/st4sd-runtime-core
+COPY --from=0 /venvs/ /venvs/
+COPY --from=0 /st4sd-runtime-core/dist /st4sd-runtime-core/dist
+
+
+# VV: Activate the virtual environment
+ENV PIP_DEFAULT_TIMEOUT=120
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+
+RUN elaunch.py -h && \
+    elaunch.py --version
+
+CMD elaunch.py -h

--- a/requirement_files/requirements_base_3.7.txt
+++ b/requirement_files/requirements_base_3.7.txt
@@ -1,0 +1,4 @@
+# Numpy dropped support for python 3.7 in v1.22
+numpy < 1.22
+# Matplotlib dropped support for python 3.7 in v3.6.0
+matplotlib < 3.6.0

--- a/requirement_files/requirements_base_3.txt
+++ b/requirement_files/requirements_base_3.txt
@@ -3,5 +3,7 @@
 cython
 reactivex >= 4.0.0
 
-# VV: Set pytest-xdist to 1.34.0 to address some inconsistencies with test_control.py in python 3 (see #1093)
+# VV: Set pytest-xdist to 1.34.0 to address some inconsistencies with test_control.py in python 3
+# pytest-xdist: With python3 a particular unit-test fails with xdist >2. T
+#   Issue is not resolved -> see https://github.ibm.com/hartreechem/flow/issues/1097 and linked issues
 pytest-xdist==1.34.0

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ here = path.abspath(path.dirname(__file__))
 # Get the long description from the relevant file
 with open(path.join(here, 'README.MD'), encoding='utf-8') as f:
     long_description = f.read()
-   
+
 setup(
     name='st4sd-runtime-core',
 
-    use_scm_version = {"root": ".", "relative_to": __file__},
+    use_scm_version={"root": ".", "relative_to": __file__, "local_scheme": "no-local-version"},
     setup_requires=['setuptools_scm'],
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
@@ -57,6 +57,7 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
     # What does your project relate to?
@@ -72,11 +73,9 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     # Notes:
-    # rx version dep. Rx movd to 3.x after 1.6.1 which introduced new API
-    # pytest-xdist: With python3 a particular unit-test fails with xdist >2. T
-    #   Issue is not resolved -> see https://github.ibm.com/hartreechem/flow/issues/1097 and linked issues
+    # rx version dep. Rx moved to 3.x after 1.6.1 which introduced new API
     install_requires=['reactivex>=4.0.0', 'pyyaml', 'pytest', 'pytest-xdist', 'pytest-timeout',
-                      'networkx', 'matplotlib<3.4.0', 'requests', 'six', 'kubernetes', 'psutil', 'boto3',
+                      'networkx', 'matplotlib', 'requests', 'six', 'kubernetes', 'psutil', 'boto3',
                       'pyrsistent', 'js2py', 'pymongo>=4.0', 'papermill', 'pandas', 'future', 'pydantic',
                       'keyring', 'typer'], #, 'pygraphviz'],
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ basepython=
 setenv= LC_ALL=en_GB.UTF-8
 deps =
     {py37,py38,py39,py310}: -rrequirement_files/requirements_base_3.txt
+    {py37}: -rrequirement_files/requirements_base_3.7.txt
     lsf: -rrequirement_files/requirements_lsf.txt
 allowlist_externals=printenv
      git


### PR DESCRIPTION
## Context

We would like to be able to build 3.10 images and pip-wheels.

## Change list

- python 3.10 image based on ubuntu 22.04
- updates to tox.ini and setup.py to support building pip wheels for python 3.10
