### PR TITLE
build: on a git tag simply create the :release-candidate image and do not push to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
       if: (branch = main AND type != pull_request) OR (tag IS present)
     - name: multiarch
       if: (branch = main AND type != pull_request) OR (tag IS present)
-    - name: update_image_and_wheel_versions
+    - name: release_candidate_image
       if: tag is present
 
 before_script:
@@ -188,7 +188,7 @@ jobs:
         --deploymentMessage="Deployment to artifactory-py${BUILD_PYTHON_VERSION}-multiarch created by travis"
       - cat *.log
 
-  - stage: update_image_and_wheel_versions
+  - stage: release_candidate_image
     before_install: []
     os: linux
     services: docker

--- a/deploy/st4sd-runtime-core-release-tag.deploy
+++ b/deploy/st4sd-runtime-core-release-tag.deploy
@@ -1,10 +1,5 @@
-before-deploy:
-    - pip3 install twine
-    - python setup.py sdist bdist_wheel
 deploy:
-    # VV: For the time being, don't bother with non-x86 images
     - docker run --rm -it
         --env DOCKER_REGISTRY --env DOCKER_TOKEN --env DOCKER_USERNAME
         -v `pwd`/deploy:/scripts -w /scripts --entrypoint /scripts/skopeo_copy.sh quay.io/skopeo/stable
         ${IMAGE_BASE_URL}:${PUSH_MANIFEST_TAG} ${IMAGE_BASE_URL}:release-candidate
-    - twine upload --repository-url "${PYPI_URL}" -u "${PYPI_USERNAME}" -p "${PYPI_TOKEN}" "dist/*"


### PR DESCRIPTION
## Context

The `image` stage will have already pushed the pip-wheel to pypi. If we try to push the
same wheel twice Pypi raises a 400 error because the uploaded file has a filename conflict
with an existing wheel (the one that `image` just pushed).

## Change list

- Travis pipeline will not push the pip wheel twice on a git-tag

## Checklist

Ensure your PR meets the following requirements:

- ~This PR is associated to one (or more) issues that are open~ (CI/CD is running on different GH server)
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
