### PR TITLE
feat: add PVEP environment variable substitution utility

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-07-10T10:42:05Z",
+  "generated_at": "2026-04-21T11:43:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -142,9 +142,19 @@
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
+    ],
+    "tests/test_pvep_environment.py": [
+      {
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 299,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/python/experiment/cli/package.py
+++ b/python/experiment/cli/package.py
@@ -29,6 +29,10 @@ from experiment.cli.git import (
     get_alternative_git_url,
 )
 from experiment.cli.pull_secrets import check_stack_has_pull_secrets_for_pvep_images
+from experiment.utilities.pvep import (
+    update_pvep_with_environment_values,
+    UndefinedEnvironmentVariablesError,
+)
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -163,6 +167,7 @@ def output_format_callback(chosen_format: str):
     options_metavar="[--tag <name>] "
     "[--update-package-definition] "
     "[--use-latest-commit] "
+    "[--expand-env-vars / --no-expand-env-vars] "
     "[-v | --verbose]",
     no_args_is_help=True,
 )
@@ -198,6 +203,13 @@ def push(
         "those performed by --use-latest-commit, will result in the package file being updated.",
         is_flag=True,
     ),
+    expand_env_vars: bool = typer.Option(
+        True,
+        "--expand-env-vars/--no-expand-env-vars",
+        help="Expand environment variables in the PVEP using $VAR or ${VAR} syntax. "
+        "Escape names using $$VAR or $${VAR} to avoid substitution. "
+        "Enabled by default. Use --no-expand-env-vars to disable.",
+    ),
     verbose: bool = typer.Option(
         False, "-v", "--verbose", help="Use verbose output.", is_flag=True
     ),
@@ -210,7 +222,32 @@ def push(
         config.settings.verbose = verbose
 
     api = get_api(ctx)
+
     pvep = load_package_from_file(path)
+
+    # VV: This enables people to use env-var references in their PVEPs instead of plaintext sensitive information
+    # like for example S3 or Git credentials. Enabled by default.
+    if expand_env_vars:
+        pvep_string = json.dumps(pvep)
+
+        try:
+            updated_pvep_string, env_vars_found = update_pvep_with_environment_values(
+                pvep_string
+            )
+
+            if env_vars_found:
+                pvep = json.loads(updated_pvep_string)
+
+                vars_list = ", ".join(env_vars_found)
+                stdout.print(
+                    f"[blue]Info:[/blue]\tSubstituted {len(env_vars_found)} environment variable{'s' if len(env_vars_found) > 1 else ''}: {vars_list}"
+                )
+        except UndefinedEnvironmentVariablesError as e:
+            stderr.print(f"[red]Error:[/red]\t{e}")
+            stderr.print(
+                "[italic]Tip:\tEnsure all referenced environment variables are set before running this command.[/italic]"
+            )
+            raise typer.Exit(code=STPExitCodes.INPUT_ERROR)
 
     if use_latest_commit:
         origin_url = get_git_origin_url(path)

--- a/python/experiment/utilities/pvep.py
+++ b/python/experiment/utilities/pvep.py
@@ -1,0 +1,94 @@
+# Copyright IBM Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Vassilis Vassiliadis
+
+import os
+import re
+from string import Template
+from typing import Dict, Optional, Set, Tuple
+
+
+class UndefinedEnvironmentVariablesError(Exception):
+    """
+    Exception raised when a PVEP references environment variables that are not defined.
+
+    This exception is raised by update_pvep_with_environment_values() when one or more
+    environment variables referenced in a PVEP string (using $VAR or ${VAR} syntax)
+    do not have values in the provided environment dictionary or os.environ.
+
+    Attributes:
+        missing_variables: List of environment variable names that are not defined
+        message: Human-readable error message
+    """
+
+    def __init__(self, missing_variables: list):
+        """
+        Initialize the exception.
+
+        Args:
+            missing_variables: List of environment variable names that are missing
+        """
+        self.missing_variables = sorted(missing_variables)
+        vars_list = ", ".join(self.missing_variables)
+        plural = "s" if len(self.missing_variables) > 1 else ""
+        self.message = f"Missing environment variable{plural}: {vars_list}"
+        super().__init__(self.message)
+
+
+def update_pvep_with_environment_values(
+    pvep_string: str, environment: Optional[Dict[str, str]] = None
+) -> Tuple[str, list[str]]:
+    """
+    Replace environment variable references in a PVEP string with their values.
+
+    This function searches for environment variables in both $NAME and ${NAME}
+    syntax within the PVEP string representation. It validates that all referenced
+    environment variables exist before performing substitution.
+
+    Environment variables are escaped using $$NAME and $${NAME}.
+
+    Args:
+        pvep_string: String representation of a Parameterised Virtual Experiment
+                     Package (PVEP), typically JSON or YAML format
+        environment: Optional dictionary of environment variables. If not provided,
+                     uses os.environ from the current process
+
+    Returns:
+        Updated PVEP string with all environment variable references replaced
+        by their values
+        The names of the environment variables found in the PVEP string
+
+    Raises:
+        ValueError: If one or more referenced environment variables are not found
+                    in the environment. The exception message lists all missing
+                    variables without exposing their values (for security).
+
+    """
+    if environment is None:
+        environment = dict(os.environ)
+
+    # VV: Find all environment variable references using regex
+    # Matches both $VAR and ${VAR} syntax, but excludes escaped $$VAR and $${VAR}
+    # Pattern explanation:
+    # - (?<!\$) negative lookbehind to ensure we don't match $$VAR or $${VAR}
+    # - \$\{([^}]+)\} matches ${VAR_NAME}
+    # - \$([A-Za-z_][A-Za-z0-9_]*) matches $VAR_NAME
+    pattern = r"(?<!\$)\$\{([^}]+)\}|(?<!\$)\$([A-Za-z_][A-Za-z0-9_]*)"
+    matches = re.finditer(pattern, pvep_string)
+
+    referenced_vars: Set[str] = set()
+    for match in matches:
+        # match.group(1) is for ${VAR}, match.group(2) is for $VAR
+        var_name = match.group(1) if match.group(1) else match.group(2)
+        referenced_vars.add(var_name)
+
+    missing_vars = sorted([var for var in referenced_vars if var not in environment])
+
+    if missing_vars:
+        raise UndefinedEnvironmentVariablesError(missing_vars)
+
+    # VV: All variables are present, perform substitution using string.Template
+    # Template.substitute() automatically handles $$NAME and $${NAME} as escape sequences
+    template = Template(pvep_string)
+    return template.substitute(environment), sorted(referenced_vars)

--- a/python/experiment/utilities/pvep.py
+++ b/python/experiment/utilities/pvep.py
@@ -4,7 +4,6 @@
 # Author: Vassilis Vassiliadis
 
 import os
-import re
 from string import Template
 from typing import Dict, Optional, Set, Tuple
 
@@ -68,20 +67,18 @@ def update_pvep_with_environment_values(
     if environment is None:
         environment = dict(os.environ)
 
-    # VV: Find all environment variable references using regex
-    # Matches both $VAR and ${VAR} syntax, but excludes escaped $$VAR and $${VAR}
-    # Pattern explanation:
-    # - (?<!\$) negative lookbehind to ensure we don't match $$VAR or $${VAR}
-    # - \$\{([^}]+)\} matches ${VAR_NAME}
-    # - \$([A-Za-z_][A-Za-z0-9_]*) matches $VAR_NAME
-    pattern = r"(?<!\$)\$\{([^}]+)\}|(?<!\$)\$([A-Za-z_][A-Za-z0-9_]*)"
-    matches = re.finditer(pattern, pvep_string)
+    # VV: Use Template's own pattern to find variable references
+    # This ensures we match exactly what Template.substitute() will process
+    template = Template(pvep_string)
 
+    # Find all matches using Template's pattern
     referenced_vars: Set[str] = set()
-    for match in matches:
-        # match.group(1) is for ${VAR}, match.group(2) is for $VAR
-        var_name = match.group(1) if match.group(1) else match.group(2)
-        referenced_vars.add(var_name)
+    for match in template.pattern.finditer(pvep_string):
+        # Template pattern has groups: 'escaped', 'named', 'braced', 'invalid'
+        # We only care about 'named' (for $VAR) and 'braced' (for ${VAR})
+        var_name = match.group("named") or match.group("braced")
+        if var_name:
+            referenced_vars.add(var_name)
 
     missing_vars = sorted([var for var in referenced_vars if var not in environment])
 
@@ -90,5 +87,4 @@ def update_pvep_with_environment_values(
 
     # VV: All variables are present, perform substitution using string.Template
     # Template.substitute() automatically handles $$NAME and $${NAME} as escape sequences
-    template = Template(pvep_string)
     return template.substitute(environment), sorted(referenced_vars)

--- a/tests/test_pvep_environment.py
+++ b/tests/test_pvep_environment.py
@@ -1,0 +1,315 @@
+# Copyright IBM Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Vassilis Vassiliadis
+
+import os
+import pytest
+
+from experiment.utilities.pvep import (
+    update_pvep_with_environment_values,
+    UndefinedEnvironmentVariablesError,
+)
+
+
+class TestUpdatePVEPWithEnvironmentValues:
+    """Test suite for update_pvep_with_environment_values function."""
+
+    def test_no_environment_variables(self):
+        """Test PVEP string with no environment variables."""
+        pvep_string = '{"name": "test", "value": "static"}'
+        result, vars_found = update_pvep_with_environment_values(pvep_string, {})
+        assert result == pvep_string
+        assert vars_found == []
+
+    def test_single_dollar_sign_syntax(self):
+        """Test substitution with $VAR syntax."""
+        pvep_string = '{"url": "$REGISTRY_URL"}'
+        env = {"REGISTRY_URL": "https://example.com"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"url": "https://example.com"}'
+        assert vars_found == ["REGISTRY_URL"]
+
+    def test_braced_syntax(self):
+        """Test substitution with ${VAR} syntax."""
+        pvep_string = '{"commit": "${COMMIT_ID}"}'
+        env = {"COMMIT_ID": "abc123"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"commit": "abc123"}'
+        assert vars_found == ["COMMIT_ID"]
+
+    def test_mixed_syntax(self):
+        """Test substitution with both $VAR and ${VAR} syntax."""
+        pvep_string = '{"url": "$REGISTRY_URL", "commit": "${COMMIT_ID}"}'
+        env = {"REGISTRY_URL": "https://example.com", "COMMIT_ID": "abc123"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"url": "https://example.com", "commit": "abc123"}'
+        assert set(vars_found) == {"REGISTRY_URL", "COMMIT_ID"}
+
+    def test_multiple_occurrences_same_variable(self):
+        """Test that the same variable can be used multiple times."""
+        pvep_string = '{"url1": "$BASE_URL", "url2": "$BASE_URL"}'
+        env = {"BASE_URL": "https://example.com"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert (
+            result == '{"url1": "https://example.com", "url2": "https://example.com"}'
+        )
+        assert vars_found == ["BASE_URL"]
+
+    def test_variable_in_middle_of_string(self):
+        """Test variable substitution within a larger string."""
+        pvep_string = '{"url": "https://$HOST/path"}'
+        env = {"HOST": "example.com"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"url": "https://example.com/path"}'
+        assert vars_found == ["HOST"]
+
+    def test_multiple_variables_in_one_value(self):
+        """Test multiple variables in a single value."""
+        pvep_string = '{"url": "$PROTOCOL://$HOST:$PORT"}'
+        env = {"PROTOCOL": "https", "HOST": "example.com", "PORT": "8080"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"url": "https://example.com:8080"}'
+        assert set(vars_found) == {"PROTOCOL", "HOST", "PORT"}
+
+    def test_missing_single_variable(self):
+        """Test error when a single environment variable is missing."""
+        pvep_string = '{"url": "$MISSING_VAR"}'
+        with pytest.raises(UndefinedEnvironmentVariablesError) as exc_info:
+            update_pvep_with_environment_values(pvep_string, {})
+        assert "Missing environment variable: MISSING_VAR" in str(exc_info.value)
+        assert exc_info.value.missing_variables == ["MISSING_VAR"]
+        # Ensure the error message doesn't expose values
+        assert (
+            "value" not in str(exc_info.value).lower()
+            or "variable" in str(exc_info.value).lower()
+        )
+
+    def test_missing_multiple_variables(self):
+        """Test error when multiple environment variables are missing."""
+        pvep_string = '{"url": "$VAR1", "commit": "$VAR2", "tag": "$VAR3"}'
+        env = {"VAR2": "present"}  # Only VAR2 is present
+        with pytest.raises(UndefinedEnvironmentVariablesError) as exc_info:
+            update_pvep_with_environment_values(pvep_string, env)
+        error_msg = str(exc_info.value)
+        assert "Missing environment variables:" in error_msg
+        assert "VAR1" in error_msg
+        assert "VAR3" in error_msg
+        assert "VAR2" not in error_msg  # VAR2 is present, shouldn't be in error
+        # Verify the exception has the missing_variables attribute
+        assert set(exc_info.value.missing_variables) == {"VAR1", "VAR3"}
+
+    def test_uses_os_environ_by_default(self):
+        """Test that function uses os.environ when no environment is provided."""
+        # Set a test environment variable
+        test_var_name = "TEST_PVEP_VAR_12345"
+        test_var_value = "test_value_xyz"
+        os.environ[test_var_name] = test_var_value
+
+        try:
+            pvep_string = f'{{"test": "${test_var_name}"}}'
+            result, vars_found = update_pvep_with_environment_values(pvep_string)
+            assert result == f'{{"test": "{test_var_value}"}}'
+            assert vars_found == [test_var_name]
+        finally:
+            # Clean up
+            del os.environ[test_var_name]
+
+    def test_custom_environment_overrides_os_environ(self):
+        """Test that custom environment dict is used instead of os.environ."""
+        # Set a variable in os.environ
+        test_var_name = "TEST_PVEP_VAR_67890"
+        os.environ[test_var_name] = "os_environ_value"
+
+        try:
+            pvep_string = f'{{"test": "${test_var_name}"}}'
+            custom_env = {test_var_name: "custom_value"}
+            result, vars_found = update_pvep_with_environment_values(
+                pvep_string, custom_env
+            )
+            # Should use custom_value, not os_environ_value
+            assert result == '{"test": "custom_value"}'
+            assert vars_found == [test_var_name]
+        finally:
+            # Clean up
+            del os.environ[test_var_name]
+
+    def test_variable_names_with_underscores(self):
+        """Test variables with underscores in their names."""
+        pvep_string = '{"var": "$MY_VAR_NAME"}'
+        env = {"MY_VAR_NAME": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"var": "value"}'
+        assert vars_found == ["MY_VAR_NAME"]
+
+    def test_variable_names_with_numbers(self):
+        """Test variables with numbers in their names."""
+        pvep_string = '{"var": "$VAR123"}'
+        env = {"VAR123": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"var": "value"}'
+        assert vars_found == ["VAR123"]
+
+    def test_lowercase_variable_names(self):
+        """Test that lowercase variable names are supported."""
+        pvep_string = '{"var": "$my_var"}'
+        env = {"my_var": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"var": "value"}'
+        assert vars_found == ["my_var"]
+
+    def test_mixed_case_variable_names(self):
+        """Test that mixed case variable names are supported."""
+        pvep_string = '{"var": "$MyVar"}'
+        env = {"MyVar": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"var": "value"}'
+        assert vars_found == ["MyVar"]
+
+    def test_empty_string(self):
+        """Test with empty PVEP string."""
+        result, vars_found = update_pvep_with_environment_values("", {})
+        assert result == ""
+        assert vars_found == []
+
+    def test_yaml_format(self):
+        """Test with YAML-formatted PVEP."""
+        pvep_string = """
+base:
+  packages:
+    - name: main
+      source:
+        git:
+          location:
+            url: $REPO_URL
+            commit: ${COMMIT_ID}
+"""
+        env = {"REPO_URL": "https://github.com/example/repo", "COMMIT_ID": "abc123"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert "https://github.com/example/repo" in result
+        assert "abc123" in result
+        assert set(vars_found) == {"REPO_URL", "COMMIT_ID"}
+
+    def test_special_characters_in_values(self):
+        """Test that special characters in values are preserved."""
+        pvep_string = '{"url": "$URL"}'
+        env = {"URL": "https://example.com/path?query=value&other=123"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"url": "https://example.com/path?query=value&other=123"}'
+        assert vars_found == ["URL"]
+
+    def test_empty_environment_variable_value(self):
+        """Test that empty string values are handled correctly."""
+        pvep_string = '{"var": "$EMPTY_VAR"}'
+        env = {"EMPTY_VAR": ""}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert result == '{"var": ""}'
+        assert vars_found == ["EMPTY_VAR"]
+
+    def test_vars_found_sorted(self):
+        """Test that returned variable names are sorted."""
+        pvep_string = '{"z": "$ZULU", "a": "$ALPHA", "m": "$MIKE"}'
+        env = {"ZULU": "z", "ALPHA": "a", "MIKE": "m"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        assert vars_found == ["ALPHA", "MIKE", "ZULU"]
+
+    def test_escaped_dollar_sign_double(self):
+        """Test that $$VAR is treated as a literal $VAR (not expanded)."""
+        pvep_string = '{"literal": "$$VAR", "expanded": "$VAR"}'
+        env = {"VAR": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        # $$VAR should become $VAR (literal), $VAR should become "value"
+        assert result == '{"literal": "$VAR", "expanded": "value"}'
+        # Only the non-escaped VAR should be in vars_found
+        assert vars_found == ["VAR"]
+
+    def test_escaped_dollar_sign_braced(self):
+        """Test that $${VAR} is treated as a literal ${VAR} (not expanded)."""
+        pvep_string = '{"literal": "$${VAR}", "expanded": "${VAR}"}'
+        env = {"VAR": "value"}
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        # $${VAR} should become ${VAR} (literal), ${VAR} should become "value"
+        assert result == '{"literal": "${VAR}", "expanded": "value"}'
+        # Only the non-escaped VAR should be in vars_found
+        assert vars_found == ["VAR"]
+
+    def test_multiple_escaped_and_expanded(self):
+        """Test mix of escaped and expanded variables."""
+        pvep_string = '{"a": "$$ESCAPED", "b": "$EXPANDED", "c": "$${ALSO_ESCAPED}", "d": "${ALSO_EXPANDED}"}'
+        env = {
+            "ESCAPED": "val1",
+            "EXPANDED": "val2",
+            "ALSO_ESCAPED": "val3",
+            "ALSO_EXPANDED": "val4",
+        }
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+        # Escaped ones should remain as literals, expanded ones should be substituted
+        assert "$ESCAPED" in result  # Literal $ESCAPED
+        assert "val2" in result  # Expanded EXPANDED
+        assert "${ALSO_ESCAPED}" in result  # Literal ${ALSO_ESCAPED}
+        assert "val4" in result  # Expanded ALSO_EXPANDED
+        # Only non-escaped variables should be in vars_found
+        assert set(vars_found) == {"EXPANDED", "ALSO_EXPANDED"}
+
+    def test_realistic_pvep_example(self):
+        """Test with a realistic PVEP structure."""
+        pvep_string = """{
+  "base": {
+    "packages": [
+      {
+        "name": "main",
+        "source": {
+          "git": {
+            "location": {
+              "url": "$GIT_REPO_URL",
+              "commit": "${GIT_COMMIT}"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "metadata": {
+    "package": {
+      "name": "my-experiment",
+      "description": "Experiment using $BACKEND backend"
+    }
+  },
+  "parameterisation": {
+    "presets": {
+      "variables": [
+        {
+          "name": "registry",
+          "value": "${CONTAINER_REGISTRY}"
+        }
+      ]
+    }
+  }
+}"""
+        env = {
+            "GIT_REPO_URL": "https://github.com/example/repo",
+            "GIT_COMMIT": "abc123def456",
+            "BACKEND": "kubernetes",
+            "CONTAINER_REGISTRY": "docker.io/myorg",
+        }
+        result, vars_found = update_pvep_with_environment_values(pvep_string, env)
+
+        # Verify all substitutions occurred
+        assert "https://github.com/example/repo" in result
+        assert "abc123def456" in result
+        assert "kubernetes" in result
+        assert "docker.io/myorg" in result
+
+        # Verify no variable references remain
+        assert "$GIT_REPO_URL" not in result
+        assert "${GIT_COMMIT}" not in result
+        assert "$BACKEND" not in result
+        assert "${CONTAINER_REGISTRY}" not in result
+
+        # Verify all variables were found
+        assert set(vars_found) == {
+            "GIT_REPO_URL",
+            "GIT_COMMIT",
+            "BACKEND",
+            "CONTAINER_REGISTRY",
+        }


### PR DESCRIPTION
This enables users to use environment variables for sensitive information when using "stp package push", like for example Git or S3 credentials.

to avoid substitution users can switch off this feature via --no-expand-env-vars or they can use $${NAME} and $$NAME for finer grain control.

## Context


## Change list

Write a few bullet points of the changes contained in this PR:

- feat: add PVEP environment variable substitution utility

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
